### PR TITLE
Add Competitive Programming Workshop 2026 event

### DIFF
--- a/src/assets/events/CP-workshop-2026.md
+++ b/src/assets/events/CP-workshop-2026.md
@@ -1,0 +1,64 @@
+---
+title: Competitive Programming Workshop 2026
+date: 2026-05-02
+time: |
+  Workshop: 2nd May 2026, 10:00 AM – 1:00 PM (Offline)
+  Practice Contest: 2nd May 2026, 8:30 PM – 10:30 PM (Online)
+type: Workshop
+slug: cp-workshop-2026
+image: ../images/events/CP_Workshop.jpeg
+registration: 
+markdownType: event
+---
+
+🚀 **Greetings Juniors!**
+
+Turing Hut is excited to welcome you to our exclusive:
+
+# 🔥 Competitive Programming Workshop 🔥
+
+**📅 Date:** 2nd May 2026 (Saturday)  
+**🕙 Workshop Time:** 10:00 AM – 3:40 PM  
+**📍 Mode:** Offline  
+**🎯 Open to:** All First-Year Students (All Branches - VNR VJIET)
+
+---
+
+Whether you're just getting started with Competitive Programming or looking to strengthen your fundamentals, this workshop is the perfect place to begin your journey.
+
+During the workshop, you'll learn about:
+
+- Popular Competitive Programming platforms such as HackerRank, Codeforces, LeetCode, and more.
+- Core problem-solving techniques and essential programming concepts.
+- Contest strategies and tips to approach coding problems efficiently.
+- Best practices to kickstart your Competitive Programming journey with confidence.
+
+---
+
+## 💻 Practice Contest – 2nd May 2026, 8:30 PM – 10:30 PM
+
+Put your learning into action through a real coding contest experience on **HackerRank**.
+
+- Experience a real Competitive Programming contest.
+- Assess your current problem-solving skills.
+- Apply the concepts learned during the workshop.
+- Challenge yourself in a friendly competitive environment.
+
+**Platform:** HackerRank
+
+> **Note:** This contest is conducted purely for practice and learning purposes. It will **not** be considered for any selection process.
+
+---
+
+Don't just learn Competitive Programming—experience it firsthand. Attend the workshop, participate in the contest, and take the first step towards becoming a better problem solver.
+
+---
+
+**Organised by:**  
+Department of CSE, Turing Hut, Programming Club of VNR VJIET
+
+**Exclusively for 1st years, all branches!**
+
+**For queries:**  
+Balaji: 9642296219  
+Jahnavi: 7207062311

--- a/src/assets/events/CP-workshop-2026.md
+++ b/src/assets/events/CP-workshop-2026.md
@@ -2,7 +2,7 @@
 title: Competitive Programming Workshop 2026
 date: 2026-05-02
 time: |
-  Workshop: 2nd May 2026, 10:00 AM – 1:00 PM (Offline)
+  Workshop: 2nd May 2026, 10:00 AM – 3:40 PM (Offline)
   Practice Contest: 2nd May 2026, 8:30 PM – 10:30 PM (Online)
 type: Workshop
 slug: cp-workshop-2026
@@ -58,7 +58,3 @@ Don't just learn Competitive Programming—experience it firsthand. Attend the w
 Department of CSE, Turing Hut, Programming Club of VNR VJIET
 
 **Exclusively for 1st years, all branches!**
-
-**For queries:**  
-Balaji: 9642296219  
-Jahnavi: 7207062311


### PR DESCRIPTION
## Summary
- Added the Competitive Programming Workshop 2026 event page.
- Included details for the one-day offline workshop.
- Added the practice contest schedule and event information.
- Followed the existing event page format for consistency.