### PR TITLE
fix: resolve image extension mismatch for team members

### DIFF
--- a/src/assets/team_data.json
+++ b/src/assets/team_data.json
@@ -723,7 +723,7 @@
     "2026-2027": [
     {
       "name": "Souchith Reddy",
-      "image": "Souchith_2027.jpeg",
+      "image": "Souchith_2027.jpg",
       "designation": "Problem Setting",
       "linkedin": "https://www.linkedin.com/in/souchithreddy/",
       "cpprofile": "https://codeforces.com/profile/souchith07"
@@ -843,7 +843,7 @@
     },
     {
       "name": "Anirudh Sajja",
-      "image": "Anirudh_2027.jpeg",
+      "image": "Anirudh_2027.jpg",
       "designation": "Documentation & PR",
       "linkedin": "https://www.linkedin.com/in/anirudh-sajja/"
     },


### PR DESCRIPTION
## Summary

- Fixed the profile images for Souchith Reddy and Anirudh Sajja on the Team page.
- Updated the image references in `team_data.json` to match the processed image format.
- Verified that both profile images render correctly.